### PR TITLE
Remove constant 'signature' field

### DIFF
--- a/bin/gpt_inspect.ml
+++ b/bin/gpt_inspect.ml
@@ -23,7 +23,6 @@ let print_gpt_partitions partitions =
 
 let print_gpt_header gpt =
   Printf.printf "GPT header:\n";
-  Printf.printf "  signature: %s\n" gpt.Gpt.signature;
   Printf.printf "  revision: 0x%08lx\n" gpt.Gpt.revision;
   Printf.printf "  gpt-size: %ld\n" gpt.Gpt.header_size;
   Printf.printf "  gpt-checksum: %ld\n" gpt.Gpt.header_crc32;

--- a/lib/gpt.mli
+++ b/lib/gpt.mli
@@ -46,7 +46,6 @@ module Partition : sig
 end
 
 type t = private {
-  signature : string;
   revision : int32;
   header_size : int32;
   header_crc32 : int32;


### PR DESCRIPTION
The signature, a magic cookie, is always "EFI PART".

Fixes #8 