### PR TITLE
Marshal alternative GPT header

### DIFF
--- a/lib/gpt.mli
+++ b/lib/gpt.mli
@@ -89,7 +89,7 @@ val unmarshal : Cstruct.t -> sector_size:int ->
    @raise Invalid_argument when [buf] is too small to contain a GPT header
 *)
 
-val marshal_header : sector_size:int -> Cstruct.t -> t -> unit
+val marshal_header : sector_size:int -> primary:bool -> Cstruct.t -> t -> unit
 (** [marshal_header ~sector_size buf t] serializes the GPT header to [buf].
     The caller is expected to write the contents of [buf] to [t.current_lba]
     and [t.backup_lba]. *)

--- a/test/test_gpt.ml
+++ b/test/test_gpt.ml
@@ -167,7 +167,7 @@ let test_marshal_unmarshal () =
     512 * ((len + 511) / 512)
   in
   let buf_partition_table = Cstruct.create partition_table_len in
-  Gpt.marshal_header ~sector_size:512 buf_header morig;
+  Gpt.marshal_header ~sector_size:512 ~primary:true buf_header morig;
   Gpt.marshal_partition_table ~sector_size:512 buf_partition_table morig;
   match Gpt.unmarshal ~sector_size:512 buf_header with
   | Error e -> Alcotest.failf "Failed to parse marshalled gpt header: %s" e


### PR DESCRIPTION
We need to swap current_lba and alternate_lba in the alternative (or "backup") GPT header, and then the checksum needs to be recomputed. Otherwise tools like fdisk and parted will consider it corrupt.