### PR TITLE
Document ~primary, add protective_mbr function

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -1,5 +1,5 @@
 (library
  (public_name gpt)
  (name gpt)
- (libraries cstruct uuidm checkseum)
+ (libraries cstruct uuidm checkseum mbr-format)
  (modules gpt))

--- a/lib/gpt.ml
+++ b/lib/gpt.ml
@@ -419,6 +419,8 @@ let marshal_partition_table ~sector_size (buf : Cstruct.t) t =
     (Cstruct.shift buf (Int32.to_int t.num_partition_entries * Partition.sizeof))
     0
 
+(* NOTE(reynir): The protective MBR is so simple that we probably don't need
+   the mbr-format library for this. *)
 let protective_mbr ~sector_size t =
   (* XXX(reynir): unclear to me if the protective MBR should use 512 byte block size *)
   if sector_size < 512 || sector_size land 511 <> 0 then

--- a/lib/gpt.mli
+++ b/lib/gpt.mli
@@ -102,4 +102,5 @@ val marshal_partition_table : sector_size:int -> Cstruct.t -> t -> unit
 
 val protective_mbr : sector_size:int -> t -> Mbr.t
 (** [protective_mbr ~sector_size t] is the protective MBR written at LBA 0 for
-    GPT header [t] using [sector_size] byte sector size. *)
+    GPT header [t] using [sector_size] byte sector size.
+    @raise Invalid_argument if [sector_size] is not a positive multiple of 512. *)

--- a/lib/gpt.mli
+++ b/lib/gpt.mli
@@ -90,10 +90,16 @@ val unmarshal : Cstruct.t -> sector_size:int ->
 *)
 
 val marshal_header : sector_size:int -> primary:bool -> Cstruct.t -> t -> unit
-(** [marshal_header ~sector_size buf t] serializes the GPT header to [buf].
+(** [marshal_header ~sector_size ~primary buf t] serializes the GPT header to [buf].
     The caller is expected to write the contents of [buf] to [t.current_lba]
-    and [t.backup_lba]. *)
+    and [t.backup_lba]. If [primary] is true (default) [t] is marshaled as is.
+    Otherwise [t.current_lba] and [t.backup_lba] are swapped and
+    [t.header_crc32] is recomputedd. *)
 
 val marshal_partition_table : sector_size:int -> Cstruct.t -> t -> unit
 (** [marshal_partition_table ~sector_size buf t] serializes the GPT partition table to [buf].
     The caller is expected to write the contents of [buf] to [t.partition_entry_lba]. *)
+
+val protective_mbr : sector_size:int -> t -> Mbr.t
+(** [protective_mbr ~sector_size t] is the protective MBR written at LBA 0 for
+    GPT header [t] using [sector_size] byte sector size. *)


### PR DESCRIPTION
While working on [gptar](https://github.com/reynir/gptar/) and finally properly testing the marshal functions I discovered the protective MBR is **required**. I'm unsure if we should factor the size if sector size is not 512. In any case I think this is only important for software that is unaware of GPT and only recognize MBR, so probably not hugely important.

I also forgot to document the new `?primary` argument to `Gpt.marshal_header` added in the previous PR.